### PR TITLE
Fixed bug when setting submenu items in script

### DIFF
--- a/addons/RadialMenu/RadialMenu.gd
+++ b/addons/RadialMenu/RadialMenu.gd
@@ -580,9 +580,10 @@ func _get_constant(name):
 
 func _clear_items():
 	var n = $ItemIcons
-	for node in n.get_children():
-		n.remove_child(node)	
-		node.queue_free()
+	if n != null:
+		for node in n.get_children():
+			n.remove_child(node)	
+			node.queue_free()
 	
 
 func get_itemindex_from_vector(v: Vector2):


### PR DESCRIPTION
Added a check to address the case where we're setting items on a RadialMenu that's not in the scene tree yet; this allows submenus to be built dynamically in another script. Prior to this, attempting to set a submenu in code would crash.