### PR TITLE
Fixed "_get_color" and "_get_constant" function calls

### DIFF
--- a/addons/RadialMenu/RadialMenu.gd
+++ b/addons/RadialMenu/RadialMenu.gd
@@ -259,30 +259,30 @@ func _draw():
 	for i in range(count):	
 		var coords = Draw.calc_ring_segment(inner, outer, start_angle+i*item_angle, start_angle+(i+1)*item_angle, center_offset)
 		if i == selected: 
-			Draw.draw_ring_segment(self, coords, _get_color("Selected Background"), _get_color("Selected Stroke"), 0.5, true)
+			Draw.draw_ring_segment(self, coords, _get_color("SelectedBackground"), _get_color("SelectedStroke"), 0.5, true)
 		else:
 			Draw.draw_ring_segment(self, coords, _get_color("Background"), _get_color("Stroke"), 0.5, true)
 
 	# draw decorator ring segment
 	if decorator_ring_position == Position.outside:
-		var rw = _get_constant("Decorator Ring Width")
+		var rw = _get_constant("DecoratorRingWidth")
 		var coords = Draw.calc_ring_segment(outer, outer + rw, start_angle, start_angle+count*item_angle, center_offset)		
-		Draw.draw_ring_segment(self, coords, _get_color("Ring Background"), null, 0, true)
+		Draw.draw_ring_segment(self, coords, _get_color("RingBackground"), null, 0, true)
 	elif decorator_ring_position == Position.inside:
-		var rw = _get_constant("Decorator Ring Width")
+		var rw = _get_constant("DecoratorRingWidth")
 		var coords = Draw.calc_ring_segment(inner-rw, inner, start_angle, start_angle+count*item_angle, center_offset)
-		Draw.draw_ring_segment(self, coords, _get_color("Ring Background"), null, 0, true)
+		Draw.draw_ring_segment(self, coords, _get_color("RingBackground"), null, 0, true)
 		
 	# draw selection ring segment
 	if selected != -1 and not has_open_submenu():
-		var selector_size = _get_constant("Selector Segment Width")		
+		var selector_size = _get_constant("SelectorSegmentWidth")		
 		var select_coords
 		if selector_position == Position.outside:
 			select_coords = Draw.calc_ring_segment(outer, outer+selector_size, start_angle+selected*item_angle, start_angle+(selected+1)*item_angle, center_offset)			
-			Draw.draw_ring_segment(self, select_coords, _get_color("Selector Segment"), null, 0, true)	
+			Draw.draw_ring_segment(self, select_coords, _get_color("SelectorSegment"), null, 0, true)	
 		elif selector_position == Position.inside:
 			select_coords = Draw.calc_ring_segment(inner-selector_size, inner, start_angle+selected*item_angle, start_angle+(selected+1)*item_angle, center_offset)
-			Draw.draw_ring_segment(self, select_coords, _get_color("Selector Segment"), null, 0, true)	
+			Draw.draw_ring_segment(self, select_coords, _get_color("SelectorSegment"), null, 0, true)	
 
 	if center_radius != 0:
 		_draw_center()
@@ -291,16 +291,16 @@ func _draw():
 func _draw_center():
 	if is_submenu:
 		return
-	var bg = _get_color("Center Background")
-	var fg = _get_color("Center Stroke")
+	var bg = _get_color("CenterBackground")
+	var fg = _get_color("CenterStroke")
 	if selected == -1:		
-		fg = _get_color("Selector Segment")
+		fg = _get_color("SelectorSegment")
 	var tex = CLOSE_TEXTURE
 	if active_submenu_idx != -1:
 		tex = BACK_TEXTURE
 	draw_circle(center_offset, center_radius, bg)
 	draw_arc(center_offset, center_radius, 0, 2*PI, center_radius, fg, 2, true)
-	draw_texture(tex, center_offset-CLOSE_TEXTURE.get_size()/2, _get_color("Icon Modulation"))
+	draw_texture(tex, center_offset-CLOSE_TEXTURE.get_size()/2, _get_color("IconModulation"))
 
 
 func setup_gamepad(deviceid : int, xaxis : int, yaxis: int, deadzone : float = JOY_DEADZONE):
@@ -476,7 +476,7 @@ func _create_item_icons():
 			sprite.centered = true
 			sprite.texture = item.texture
 			sprite.scale = Vector2(icon_scale, icon_scale)
-			sprite.modulate = _get_color("Icon Modulation")
+			sprite.modulate = _get_color("IconModulation")
 			$ItemIcons.add_child(sprite)
 	_item_children_present = true
 
@@ -507,7 +507,7 @@ func _update_item_icons():
 			ni += 1
 			sprite.position = coords[i]			
 			sprite.scale = Vector2(icon_scale, icon_scale)
-			sprite.modulate = _get_color("Icon Modulation")
+			sprite.modulate = _get_color("IconModulation")
 		i=i+1
 
 
@@ -520,10 +520,10 @@ func get_inner_outer():
 	var outer
 	var drw = 0
 	if decorator_ring_position == Position.outside:
-		drw = _get_constant("Decorator Ring Width")
+		drw = _get_constant("DecoratorRingWidth")
 	
 	if selector_position == Position.outside:
-		var w = max(drw, _get_constant("Selector Segment Width"))
+		var w = max(drw, _get_constant("SelectorSegmentWidth"))
 		inner = radius - w - width 
 		outer = radius - w
 	else:
@@ -536,8 +536,8 @@ func get_total_ring_width():
 	"""
 	Returns the total width of the ring (with decorator and selector)
 	"""
-	var dw = _get_constant("Decorator Ring Width")
-	var sw = _get_constant("Selector Segment Width")
+	var dw = _get_constant("DecoratorRingWidth")
+	var sw = _get_constant("SelectorSegmentWidth")
 	if decorator_ring_position == selector_position:
 		if decorator_ring_position == Position.off:
 			return width
@@ -558,9 +558,9 @@ func get_icon_radius():
 	var so_width = 0
 	var dr_width = 0
 	if selector_position == Position.outside:
-		so_width = _get_constant("Selector Segment Width")
+		so_width = _get_constant("SelectorSegmentWidth")
 	if decorator_ring_position == Position.outside:
-		dr_width = _get_constant("Decorator Ring Width")
+		dr_width = _get_constant("DecoratorRing Width")
 	return radius - width/2.0 - max(so_width, dr_width)
 
 		

--- a/addons/RadialMenu/RadialMenu.gd
+++ b/addons/RadialMenu/RadialMenu.gd
@@ -560,7 +560,7 @@ func get_icon_radius():
 	if selector_position == Position.outside:
 		so_width = _get_constant("SelectorSegmentWidth")
 	if decorator_ring_position == Position.outside:
-		dr_width = _get_constant("DecoratorRing Width")
+		dr_width = _get_constant("DecoratorRingWidth")
 	return radius - width/2.0 - max(so_width, dr_width)
 
 		


### PR DESCRIPTION
### **What happend?**
The "_get_color" and "_get_constant" function calls could not get the Theme Property, as a Theme Property cannot have spaces in the name, i removed the spaces and tested it using a custom theme (  just for testing ) that has the Propertys the functions ask for but now i am getting an error from "drawing_library.gd" when hovering over an item.

### **The Error**
```
E 0:00:03.529   canvas_item_add_polygon: Invalid polygon data, triangulation failed.
  <C++ Error>   Condition "indices.empty()" is true.
  <C++ Source>  servers/visual/visual_server_canvas.cpp:768 @ canvas_item_add_polygon()
  <Stack Trace> drawing_library.gd:123 @ draw_ring_segment()
                RadialMenu.gd:285 @ _draw()
```
I dont have a solution to fix that error for now, but i am searching for one.

### **The Theme :** 
![image_2023-12-06_165914976](https://github.com/jesuisse/godot-radial-menu-control/assets/109413186/3ca0fc19-e872-4008-a276-d57c2f89e5a3)
![image](https://github.com/jesuisse/godot-radial-menu-control/assets/109413186/9ba4ae44-8bf3-497d-8e52-f8e01b09c2d3)

### **The Theme in the Inspector :** 
![image](https://github.com/jesuisse/godot-radial-menu-control/assets/109413186/98c1e139-51c5-4fd2-9ad4-8c887fc30f0e)