### PR TITLE
Fix index checks for selected item in _draw_label and set_selected

### DIFF
--- a/addons/RadialMenu/RadialMenu.gd
+++ b/addons/RadialMenu/RadialMenu.gd
@@ -359,7 +359,7 @@ func _draw_center_ring():
 
 func _draw_label():	
 	var text
-	if selected == -1:
+	if selected < 0 or selected >= menu_items.size():
 		return	
 	text = menu_items[selected]['title']
 	var font = _get_font("TitleFont")
@@ -725,7 +725,7 @@ func set_selected_item(itemidx):
 		return
 	
 	selected = itemidx
-	if selected != -1:
+	if selected >= 0 and selected < menu_items.size():
 		emit_signal("item_hovered", menu_items[selected])
 		
 	queue_redraw()


### PR DESCRIPTION
If the radial menu is called while it has no items, it can cause an invalid index error, this PR aims to solve this, preventing drawing and calling set_selected if the index is invalid.