### PR TITLE
Add option to ignore title size in radial menu layout

### DIFF
--- a/addons/RadialMenu/RadialMenu.gd
+++ b/addons/RadialMenu/RadialMenu.gd
@@ -68,6 +68,8 @@ enum Position { off, inside, outside }
 @export var icon_scale := 1.0: set = _set_icon_scale
 
 @export var show_titles := true: set = _set_titles_display
+## If true, the title size will be ignored when laying out the menu items.
+@export var ignore_title_size := false
 
 
 # default menu items. They are provided so a placeholder radial menu can be displayed in the editor
@@ -366,7 +368,7 @@ func _draw_label():
 	var fontsize = _get_fontsize("TitleFont")	
 	var color = _get_color("TitleDisplay")
 	var size = font.get_string_size(text, HORIZONTAL_ALIGNMENT_CENTER, -1, fontsize)		
-	if center_radius > size.x / 2.0:
+	if ignore_title_size or center_radius > size.x / 2.0:
 		# show text if it fits inside the center ring
 		var pos = center_offset - Vector2(size.x/2.0, -font.get_descent())
 		draw_string(font, pos, text, HORIZONTAL_ALIGNMENT_CENTER, -1, fontsize, color)


### PR DESCRIPTION
Adding an option to ignore the size of titles when laying out menu items. It also updates the logic for drawing labels to respect this new option.

### New feature for title size handling:
* [`addons/RadialMenu/RadialMenu.gd`](diffhunk://#diff-ea37e3d95ac71a327278ff84d00f4b9afffebaf35d4d60f513fe8f1f0feceb26R71-R72): Added a new exported variable `ignore_title_size` to allow users to specify whether the title size should be ignored when laying out menu items.

### Update to label drawing logic:
* [`addons/RadialMenu/RadialMenu.gd`](diffhunk://#diff-ea37e3d95ac71a327278ff84d00f4b9afffebaf35d4d60f513fe8f1f0feceb26L369-R371): Modified the `_draw_label` function to include a condition that checks the new `ignore_title_size` variable, enabling text to be displayed even if it would otherwise not fit within the center radius.